### PR TITLE
Hold to calibrate

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2180,6 +2180,10 @@
   #define XPT2046_Y_OFFSET        257
 #endif
 
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+  #define HOLD_TO_CALIBRATE_DELAY 5 // seconds to hold on status screen to calibrate
+#endif
+
 //
 // RepRapWorld REPRAPWORLD_KEYPAD v1.1
 // http://reprapworld.com/?products_details&products_id=202&cPath=1591_1626

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -82,7 +82,10 @@ void Touch::idle() {
 
     if (wait_for_unclick) {
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-        if (now > long_click_end) ui.goto_screen(touch_screen_calibration);
+        if (long_click_end && now > long_click_end && ui.on_status_screen()) {
+          long_click_end = 0;
+          ui.goto_screen(touch_screen_calibration);
+        }
       #endif
       return;
     }
@@ -115,7 +118,7 @@ void Touch::idle() {
       if (current_control == NULL) {
         wait_for_unclick = true;
         #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-          long_click_end = now + (1000 * 3);
+          long_click_end = now + (1000 * HOLD_TO_CALIBRATE_DELAY);
         #endif
       }
     }

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -42,6 +42,7 @@ uint16_t Touch::controls_count;
 millis_t Touch::now = 0;
 millis_t Touch::time_to_hold;
 millis_t Touch::repeat_delay;
+millis_t Touch::long_click_end;
 bool Touch::wait_for_unclick;
 touch_calibration_t Touch::calibration;
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
@@ -79,7 +80,13 @@ void Touch::idle() {
       ui.return_to_status_ms = now + LCD_TIMEOUT_TO_STATUS;
     #endif
 
-    if (wait_for_unclick) return;
+    if (wait_for_unclick) {
+      #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+        if (now > long_click_end) ui.goto_screen(touch_screen_calibration);
+      #endif
+      return;
+    }
+
     if (time_to_hold == 0) time_to_hold = now + MINIMUM_HOLD_TIME;
     if (PENDING(now, time_to_hold)) return;
 
@@ -105,8 +112,12 @@ void Touch::idle() {
         }
       }
 
-      if (current_control == NULL)
+      if (current_control == NULL) {
         wait_for_unclick = true;
+        #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+          long_click_end = now + (1000 * 3);
+        #endif
+      }
     }
     x = _x;
     y = _y;

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -129,6 +129,7 @@ class Touch {
     static millis_t now;
     static millis_t time_to_hold;
     static millis_t repeat_delay;
+    static millis_t click_begin;
     static bool wait_for_unclick;
 
     static inline bool get_point(int16_t *x, int16_t *y);
@@ -136,6 +137,7 @@ class Touch {
     static void hold(touch_control_t *control, millis_t delay = 0);
 
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+      static millis_t long_click_end;
       static calibrationState calibration_state;
       static touch_calibration_point_t calibration_points[4];
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Allows users to press and hold on status screen to calibrate, as long as it's not on an icon (not a problem if touch is uncalibrated, usually)

### Benefits

Easier calibration.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
